### PR TITLE
Support "aarch64" reported for M1 arch

### DIFF
--- a/lib/envkey/platform.rb
+++ b/lib/envkey/platform.rb
@@ -21,7 +21,7 @@ module Envkey::Platform
     "x86"
   when /ppc|powerpc/
     "powerpc"
-  when /^arm/
+  when /^arm|^aarch/
     "arm"
   else
     cpu


### PR DESCRIPTION
Some versions of RbConfig return `aarch64` for the CPU on M1, not `arm64` or `armv8`

Fix for Issue #9.